### PR TITLE
Fix element name and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 Online Status is a simple app for displaying to a website visitor whether their device is currently connected to the internet.
 
-If you wish to use without eager simply include the js and css file like any other javescript/jquery plugin. 
+Install with Eager:
+
+<a href="https://eager.io/app/online-status/install?source=button">
+  <img src="https://install.eager.io/install-button.png" border="0" width="126">
+</a>
+
+To manually install simply include the `app.js` and `app.css` files like any other JavaScript library.

--- a/app.css
+++ b/app.css
@@ -1,4 +1,4 @@
-eager-online-state-app-state-indicator {
+eager-online-status-app-status-indicator {
   display: block;
   cursor: default;
   position: fixed;
@@ -8,11 +8,11 @@ eager-online-state-app-state-indicator {
   left: 1.25em
 }
 
-eager-online-state-app-state-indicator[is-online]:not([show-when-online]) {
+eager-online-status-app-status-indicator[is-online]:not([show-when-online]) {
   display: none
 }
 
-eager-online-state-app-state-indicator:before, eager-online-state-app-state-indicator:after {
+eager-online-status-app-status-indicator:before, eager-online-status-app-status-indicator:after {
   font-family: inherit;
   cursor: default;
   display: inline-block;
@@ -20,7 +20,7 @@ eager-online-state-app-state-indicator:before, eager-online-state-app-state-indi
   height: 100%
 }
 
-eager-online-state-app-state-indicator:before {
+eager-online-status-app-status-indicator:before {
   content: '';
   height: 1.5em;
   width: 1.5em;
@@ -31,15 +31,15 @@ eager-online-state-app-state-indicator:before {
   background: #f00
 }
 
-eager-online-state-app-state-indicator[is-online]:before {
+eager-online-status-app-status-indicator[is-online]:before {
   background: #5cca00
 }
 
-eager-online-state-app-state-indicator:not(:hover):after {
+eager-online-status-app-status-indicator:not(:hover):after {
   opacity: 0
 }
 
-eager-online-state-app-state-indicator:after {
+eager-online-status-app-status-indicator:after {
   content: 'Offline';
   pointer-events: none;
   line-height: 1.5;
@@ -48,6 +48,6 @@ eager-online-state-app-state-indicator:after {
   margin-left: .6em
 }
 
-eager-online-state-app-state-indicator[is-online]:after {
+eager-online-status-app-status-indicator[is-online]:after {
   content: 'Online'
 }

--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 (function(){
   var options = INSTALL_OPTIONS;
 
-  var statusEl = document.createElement('eager-online-state-app-state-indicator');
+  var statusEl = document.createElement('eager-online-status-app-status-indicator');
   document.body.appendChild(statusEl);
   statusEl.setAttribute('is-online', 'true');
 


### PR DESCRIPTION
@themecreek

This update fixes the element name (changes `online-state` to `online-status` to match the name of the app and repo), and adds an Eager Install Button to the README.

If you prefer to the larger “CTA”-style button, you can find more information about that in [our docs](https://eager.io/developer/docs/promoting-your-app/install-button).
