### PR TITLE
Small style change to status text

### DIFF
--- a/app.css
+++ b/app.css
@@ -49,9 +49,8 @@ eager-online-status-app-status-indicator:after {
   background-color: white;
   color: black;
   padding: 5px;
-  border-radius: 50%;
-  font-size: 0.8em;
-  text-shadow: 0em 0em 0.111em black;
+  border-radius: 5px;
+  font-size: .8em;
   font-weight: bold
 }
 


### PR DESCRIPTION
@themecreek We really like the white background color as it makes the text much easier to read in situations in which it would overlap a non-solid light background. However we feel the text shadow and ellipsis-style border-radius are unnecessary and slightly degrade readability.
